### PR TITLE
.spellcheck.yaml: Allow for a hidden file

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,6 @@ This action uses [PySpelling](https://facelessuser.github.io/pyspelling/) to
 check source files in the project.  
 
 ## Configuration
-If your repo contains `spellcheck.yaml` it will be used instead of the default config.
-See https://facelessuser.github.io/pyspelling/configuration/ for options.
+If the top-level of your repo contains `spellcheck.yaml` or
+`.spellcheck.yaml` it will be used instead of the default config. See
+https://facelessuser.github.io/pyspelling/configuration/ for options.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,10 +1,21 @@
 #!/bin/bash
-if [ ! -f ./spellcheck.yaml ]; then
-    cp /spellcheck.yaml .
+
+if [ ! -f "./spellcheck.yaml" ]; then
+    if [ -f "./.spellcheck.yaml" ]; then
+	cp ./.spellcheck.yaml spellcheck.yaml
+    else
+	cp /spellcheck.yaml .
+    fi
+elif
+
 fi
 
 if [ ! -f ./wordlist.txt ]; then
-    cp /wordlist.txt .
+    if [ -f "./.worldlist.txt" ]; then
+	cp ./.wordlist.txt wordlist.txt
+    else
+	cp /wordlist.txt .
+    fi
 fi
 
 pyspelling -c spellcheck.yaml


### PR DESCRIPTION
To keep repoistories that wish to use this action a bit cleaner, we
allow a hidden version of .spellcheck.yaml and .wordlist.txt.