### PR TITLE
Extending the support for Markdown parsing in the Docker image based on extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log for spellcheck-github-actions
 
+## 0.8.0 2021-01-08 feature release, update not required
+
+- Added support for extensions for Python's Markdown, namely the `pymdown-extensions` introducing the `superfences` extension, which can be used to address certain issue, which cannot be handled by handling of codefences by the Python Markdown implementation out of the box
+
 ## 0.7.0 2020-12-14 maintenance release, update not required
 
 - Docker image updated to Python 3.9.1 slim via PR #27 from dependabot

--- a/README.md
+++ b/README.md
@@ -214,6 +214,24 @@ jobs:
 
 This step adds an action, which checkout out the repository for inspection by linters and other actions like this one.
 
+### Diagnostic text: `ERROR: *.md -- 'NoneType' object has no attribute 'end'`
+
+This indicates issues with the Markdown and is reported by `Markdown` (See: [PyPi site](https://pypi.org/project/Markdown/)).
+
+[PySpelling][pyspelling]  does however support extension of the standard Markdown parser and you can specify the use of extensions of these are support.
+
+This action support the extensions included in: `pymdown-extensions` (See: [PyPi site](https://pypi.org/project/pymdown-extensions/))
+
+And you can then put these to use in your configuration. The example below outlines the `superfences` extension.
+
+```yaml
+  - pyspelling.filters.markdown:
+      markdown_extensions:
+      - pymdownx.superfences:
+```
+
+Please see the repositorys `requirements.txt` for a list of all included Python modules and their exact versions.
+
 ## DockerHub
 
 This action is based on a Docker image available on DockerHub.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,10 +3,11 @@ beautifulsoup4==4.9.3
 bracex==2.0.1
 html5lib==1.1
 lxml==4.6.0
-Markdown==3.3.1
 pyspelling==2.6.1
 PyYAML==5.3.1
 six==1.15.0
 soupsieve==2.0.1
 wcmatch==7.1
 webencodings==0.5.1
+markdown==3.3.1
+pymdown-extensions==8.1


### PR DESCRIPTION
Added support for extensions for Python's Markdown, namely the pymdown-extensions introducing the superfences extension, which can be used to address certain issue, which cannot be handled by handling of
codefences by the Python Markdown implementation out of the box.

Closes #28