### PR TITLE
Dockerfile - use multi-stage for performance increase & specific language installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM python:3.9.2-slim
+# default are English and German
+ARG SPELLCHECK_LANGS="en,de"
+
+# Builder stage: configure env vars, labels, add plain files, install common packages
+FROM python:3.9.2-slim as spellcheck-builder
 
 LABEL "com.github.actions.name"="Spellcheck Action"
 LABEL "com.github.actions.description"="Check spelling of files in repo"
@@ -7,73 +11,28 @@ LABEL "com.github.actions.color"="green"
 LABEL "repository"="http://github.com/rojopolis/spellcheck-github-actions"
 LABEL "homepage"="http://github.com/actions"
 LABEL "maintainer"="rojopolis <rojo@deba.cl>"
+# label as builder stage, for easy cleanup (e.g. `docker image prune --filter label=stage=builder`)
+LABEL stage=builder 
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends aspell \
-    #aspell-am \
-    #aspell-ar \
-    #aspell-bg \
-    #aspell-bn \
-    #aspell-br \
-    #aspell-ca \
-    #aspell-cs \
-    #aspell-cy \
-    #aspell-da \
-    aspell-de \
-    #aspell-el \
-    aspell-en \
-    #aspell-eo \
-    #aspell-es \
-    #aspell-et \
-    #aspell-eu \
-    #aspell-fa \
-    #aspell-fo \
-    #aspell-fr \
-    #aspell-ga \
-    #aspell-gl-minimos \
-    #aspell-gu \
-    #aspell-he \
-    #aspell-hi \
-    #aspell-hr \
-    #aspell-hsb \
-    #aspell-hu \
-    #aspell-hy \
-    #aspell-is \
-    #aspell-it \
-    #aspell-kk \
-    #aspell-kn \
-    #aspell-ku \
-    #aspell-lt \
-    #aspell-lv \
-    #aspell-ml \
-    #aspell-mr \
-    #aspell-nl \
-    #aspell-no \
-    #aspell-or \
-    #aspell-pa \
-    #aspell-pl \
-    #aspell-pt-br \
-    #aspell-pt-pt \
-    #aspell-ro \
-    #aspell-ru \
-    #aspell-sk \
-    #aspell-sl \
-    #aspell-ta \
-    #aspell-te \
-    #aspell-sv \
-    #aspell-tl \
-    #aspell-uk \
-    #aspell-uz \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
-
+COPY --chmod=755 entrypoint.sh /entrypoint.sh
 COPY requirements.txt /requirements.txt
-
-RUN pip3 install -r requirements.txt
-
 COPY spellcheck.yaml /spellcheck.yaml
+RUN pip3 install -r /requirements.txt
 
-COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+# https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get
+RUN apt-get update && apt-get install -y \
+    aspell \
+    && rm -rf /var/lib/apt/lists/*
+
+######################################################################################################
+
+# Custom built images with an arg
+FROM spellcheck-builder as spellcheck
+
+RUN apt-get update && apt-get install -y \
+    # split arg SPELLCHECK_LANGS to space separated, and prepend each with 'aspell-'
+    $(echo "$SPELLCHECK_LANGS" | sed 's/,/ /g' | xargs printf -- 'aspell-%s\n')     \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /tmp
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ LABEL "maintainer"="rojopolis <rojo@deba.cl>"
 # label as builder stage, for easy cleanup (e.g. `docker image prune --filter label=stage=builder`)
 LABEL stage=builder
 
-COPY --chmod=755 entrypoint.sh /entrypoint.sh
+COPY entrypoint.sh /entrypoint.sh
 COPY requirements.txt /requirements.txt
 COPY spellcheck.yaml /spellcheck.yaml
 RUN pip3 install -r /requirements.txt
@@ -35,4 +35,4 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /tmp
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/bin/sh", "/entrypoint.sh"]


### PR DESCRIPTION
Thanks to @edumco for his support in #13 

From what I understand, building a whole docker image for spellcheck is slow. There's a few different (and complementary) ways of fixing it. Here's my suggestion: multi-stage docker builds.

There's a base docker image that can be hosted online. This contains everything that's needed. Then when a user needs to spell check a specific language, docker-multistage fires up and takes that base image (which is just a quick cacheable(?) download), and very quickly installs the required language. 

Also, I used the new `COPY --chmod` to combine setting permissions with the copying.

### Commands for building

You can create a new image with any language you want by specifying the aspell language code in a comma-separated-list build-arg:

```bash
docker build -t spellcheck --build-arg SPELLCHECK_LANGS="en,fr,hr" .
```

The base image can be made specifically by setting the target `--target`, and tag it with `-t` 

```bash
docker build --target spellcheck-builder -t spellcheck-builder .
```

For testing performance of a fresh build, disable the cache with `--no-cache`

```bash
docker build --no-cache --target spellcheck-builder -t spellcheck-builder .
```

### Disclaimer

By the way I have very little idea about what I'm doing, or if this is even the 'best' approach. I haven't even tested it (just hacked around locally). I wanted to try learning Docker multistage, and it was fun trying!

If you have points to improve, I would really appreciate it if you picked them up and ran with them - I don't have a lot of time for contributing. And honestly I feel a bit rude, dumping a PR without testing or really being a user or part of the project. But anyway, I hope that's okay.

Final note, I found https://github.com/wagoodman/dive a really good tool for investigating layers.