### PR TITLE
Build Docker image

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,15 @@
+name: Docker Image CI
+
+on: [push, pull_request]
+
+jobs:
+
+  docker-build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag spellcheck:$(date +%s)


### PR DESCRIPTION
This adds another parallel job to github actions to build the docker image

In the future is possible to use this docker image to publish to a container registry or simply to test if it works correctly 