### PR TITLE
Implemented hack to reinstate disappearing aspell

### DIFF
--- a/.github/workflows/spelling_action.yml
+++ b/.github/workflows/spelling_action.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     # The checkout step
     - uses: actions/checkout@master
-    - uses: rojopolis/spellcheck-github-actions@0.15.0
+    - uses: rojopolis/spellcheck-github-actions@0.14.0
       name: Spellcheck
       with:
         source_files: README.md CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log for spellcheck-github-actions
 
-## 0.15.0 2021-08-13 maintenance release, update not required
+## 0.16.0 2021-08-15 bug fix release, update recommended
+
+Experienced an issue with the new multi-stage Docker build, where `aspell` _disappears_.
+
+This release implements a _hack_ to make use that it is present, by reinstalling it :-/
+
+## 0.15.0 2021-08-15 maintenance release, update not required
 
 Issue [#53](https://github.com/rojopolis/spellcheck-github-actions/issues/53) describes an issue with ignoring Markdown regions with code fences. This was an issue in `pyspelling`, which is the core component in this action. Luckily @facelessuser, the maintainer of `pyspelling` was to [fix it](https://github.com/facelessuser/pyspelling/pull/144). So the requirement for `pyspelling` was bumped from 2.6.1 to 2.7.3
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update && apt-get install -y \
 FROM spellcheck-builder as spellcheck
 
 RUN apt-get update && apt-get install -y \
+    aspell \
     # split arg SPELLCHECK_LANGS to space separated, and prepend each with 'aspell-'
     $(echo "$SPELLCHECK_LANGS" | sed 's/,/ /g' | xargs printf -- 'aspell-%s\n')     \
     && rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ jobs:
     steps:
     # The checkout step
     - uses: actions/checkout@master
-    - uses: rojopolis/spellcheck-github-actions@0.15.0
+    - uses: rojopolis/spellcheck-github-actions@0.16.0
       name: Spellcheck
 ```
 
@@ -77,7 +77,7 @@ jobs:
     steps:
     # The checkout step
     - uses: actions/checkout@master
-    - uses: rojopolis/spellcheck-github-actions@0.15.0
+    - uses: rojopolis/spellcheck-github-actions@0.16.0
       name: Spellcheck
       with:
         source_files: README.md CHANGELOG.md notes/Notes.md
@@ -150,7 +150,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: rojopolis/spellcheck-github-actions@0.15.0
+    - uses: rojopolis/spellcheck-github-actions@0.16.0
       name: Spellcheck
       with:
         config_path: config/.spellcheck.yml # put path to configuration file here
@@ -399,7 +399,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: rojopolis/spellcheck-github-actions@0.15.0
+    - uses: rojopolis/spellcheck-github-actions@0.16.0
       name: Spellcheck
 ```
 


### PR DESCRIPTION
Implemented hack to reinstate disappearing `aspell`, by reinstall in the wrong stage :-/

The issue was observed with release 0.15.0.

Closes #55 