### PR TITLE
Use ::error:: messages, reported as job summary annotations

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -44,8 +44,8 @@ pyspelling --config $SPELLCHECK_CONFIG_FILE $TASK_NAME $SOURCES_LIST
 
 EXITCODE=$?
 
-test $EXITCODE -gt 1 && echo "Spelling check action failed, please check diagnostics";
+test $EXITCODE -gt 1 && echo "::error title=Spelling check::Spelling check action failed, please check diagnostics";
 
-test $EXITCODE -eq 1 && echo "Files in repository contain spelling errors";
+test $EXITCODE -eq 1 && echo "::error title=Spelling errors::Files in repository contain spelling errors";
 
 exit $EXITCODE


### PR DESCRIPTION
This is a suggestion motivated by the fact that having the error message reported as an annotation in a failing job summary gives explicit indication about the reason for the failure, which can be informative for workflows with several steps prior to digging into the logs.

See [Workflow commands for GitHub Actions](https://docs.github.com/en/actions/learn-github-actions/workflow-commands-for-github-actions#setting-an-error-message).


You can see this in action for a dummy example repo [riccardoporreca/spellcheck-github-actions-example](https://github.com/riccardoporreca/spellcheck-github-actions-example/actions), in particular in the "Summary" of run https://github.com/riccardoporreca/spellcheck-github-actions-example/actions/runs/1382997051 and the log of job "Spellcheck with ::error::" (which uses a little trick to test the entrypoint from the fork).