### PR TITLE
Enable spanish support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # default are English and German
-ARG SPELLCHECK_LANGS="en,de"
+ARG SPELLCHECK_LANGS="en,de,es"
 
 # Builder stage: configure env vars, labels, add plain files, install common packages
 FROM python:3.10.2-slim as spellcheck-builder

--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ Currently only the following languages are supported via [GNU Aspell][aspell]:
   - German (`de_DE`),
   - Swiss (`de_CH`)
   - Austrian (`de_AT`)
+- Spanish via the [`aspell-se` Debian package][aspell-es]
 
 Additional languages can be added by request, please open an issue.
 
@@ -576,6 +577,7 @@ This repository is licensed under the MIT license.
 [aspell]: http://aspell.net/
 [aspell-de]: https://packages.debian.org/buster/aspell-de
 [aspell-en]: https://packages.debian.org/buster/aspell-en
+[aspell-es]: https://packages.debian.org/buster/aspell-es
 [GHAMKDBADGE]: https://github.com/rojopolis/spellcheck-github-actions/workflows/Markdownlint%20Action/badge.svg
 [GHASPLLBADGE]: https://github.com/rojopolis/spellcheck-github-actions/workflows/Spellcheck%20Action/badge.svg
 [expect_match]: https://facelessuser.github.io/pyspelling/configuration/#expect-match


### PR DESCRIPTION
The [CNCF glossary project](https://github.com/cncf/glossary/) is currently using this action to validate its documentation. There are plans to translate it to different languages, therefore it's necessary to include other languages like Spanish. This change can facilitate the [validation process](https://github.com/cncf/glossary/pull/360).