### PR TITLE
Fix to address issue 84; support for spaces in file paths requiring quoting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /tmp
-ENTRYPOINT ["/bin/sh", "/entrypoint.sh"]
+ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ jobs:
     steps:
     # The checkout step
     - uses: actions/checkout@master
-    - uses: rojopolis/spellcheck-github-actions@0.23.0
+    - uses: rojopolis/spellcheck-github-actions@0.23.1
       name: Spellcheck
 ```
 
@@ -78,7 +78,7 @@ jobs:
     steps:
     # The checkout step
     - uses: actions/checkout@master
-    - uses: rojopolis/spellcheck-github-actions@0.23.0
+    - uses: rojopolis/spellcheck-github-actions@0.23.1
       name: Spellcheck
       with:
         source_files: README.md CHANGELOG.md notes/Notes.md
@@ -151,7 +151,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: rojopolis/spellcheck-github-actions@0.23.0
+    - uses: rojopolis/spellcheck-github-actions@0.23.1
       name: Spellcheck
       with:
         config_path: config/.spellcheck.yml # put path to configuration file here
@@ -413,7 +413,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: rojopolis/spellcheck-github-actions@0.23.0
+    - uses: rojopolis/spellcheck-github-actions@0.23.1
       name: Spellcheck
 ```
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,52 @@ By default, this action will use the `sources:` list under each task in your con
 
 When this option is used, you must also specify the `task_name` to override the `sources:` list for.
 
+Do note that file paths containing spaces need to be quoted using either `'` (single quotes) or `"` (double quotes). The quoting has to be uniform and the two quoting styles can not be intermixed.
+
+### Examples
+
+Parts are lifted from issue [#84](https://github.com/rojopolis/spellcheck-github-actions/issues/84)
+
+#### No spaces, quotes not required
+
+```yaml
+source_files: README.md CHANGELOG.md notes/Notes.md
+```
+
+#### No spaces, quotes not required, double quotes used for complete parameter
+
+```yaml
+source_files: "README.md CHANGELOG.md notes/Notes.md"
+```
+
+This might actually work, but it is not recommended and might it might break, instead using proper quoting.
+
+#### No spaces, quotes not required, double quotes used for single parameters
+
+```yaml
+source_files: "README.md" "CHANGELOG.md" "notes/Notes.md"
+```
+
+This would also work using single quotes
+
+#### Spaces, quotes required, single quotes used
+
+```yaml
+source_files: 'Managed Services/Security Monitor/README.md' 'Terraform/Development Guide/README.md'
+```
+
+#### Spaces, quotes required, double quotes used
+
+```yaml
+source_files: "Managed Services/Security Monitor/README.md" "Terraform/Development Guide/README.md"
+```
+
+#### Spaces, quotes required, intermixed quotes, will not work
+
+```yaml
+source_files: README.md CHANGELOG.md notes/Notes.md
+```
+
 ## Specify A Specific Task To Run
 
 By default, all tasks in your config file will be run. By setting `task_name` you can override this and run only the task you require.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -l
+#!/bin/bash
 
 SPELLCHECK_CONFIG_FILE=''
 
@@ -19,17 +19,65 @@ fi
 echo ""
 echo "Using pyspelling on configuration outlined in >$SPELLCHECK_CONFIG_FILE<"
 
+SINGLE="'"
+DOUBLE='"'
+SPLIT=false
+
 if [ -n "$INPUT_SOURCE_FILES" ]; then
+
+    if grep -q $SINGLE <<< "$INPUT_SOURCE_FILES"; then
+        OIFS=$IFS
+        IFS=$SINGLE
+        SPLIT=true
+        echo "Detected separator: >$SINGLE< (single quote)"
+    fi
+
+    if grep -q $DOUBLE <<< "$INPUT_SOURCE_FILES"; then
+        OIFS=$IFS
+        IFS=$DOUBLE
+        SPLIT=true
+        echo "Detected separator: >$DOUBLE< (double quote)"
+    fi
+
     if [ -z "$INPUT_TASK_NAME" ]; then
         echo "task_name must be specified to use source_files option"
         exit 1
     else
         echo "Running task >$INPUT_TASK_NAME<"
     fi
-    for FILE in $INPUT_SOURCE_FILES; do
-        SOURCES_LIST="$SOURCES_LIST --source $FILE"
-        echo "Checking file >$FILE<"
-    done
+
+    if [ "$SPLIT" = true ]; then
+        echo "IFS = >$IFS<"
+        read -a arr <<< "$INPUT_SOURCE_FILES"
+
+        for FILE in "${arr[@]}"; do
+
+            # Skip null items
+            if [ -z "$FILE" ]; then
+                continue
+            fi
+
+            if [ "$FILE" = ' ' ]; then
+                continue
+            fi
+
+            SOURCES_LIST="$SOURCES_LIST --source $FILE"
+            echo "Checking quoted file >$FILE<"
+        
+        done
+
+        IFS=$OIFS
+        unset OIFS
+
+    else 
+        read -a arr <<< "$INPUT_SOURCE_FILES"
+
+        for FILE in "${arr[@]}"; do
+            SOURCES_LIST="$SOURCES_LIST --source $FILE"
+            echo "Checking file >$FILE<"
+        done
+    fi
+
 else
     echo "Checking files matching specified outlined in >$SPELLCHECK_CONFIG_FILE<"
 fi


### PR DESCRIPTION
- This is first shot at a fix of the issue reported in #86. I believe file paths without space has been working as a conincidence since the splitting has not been working at all, but treating the list of file names as a single string also worked.
- amend!
- Bumped version in examples for the upcoming bug fix release
- Updated the documentation to support the bug fix addressing issue #84
- Minor correction to Dockerfile, was executing as sh, but was using Bash script
