### PR TITLE
New artifact emitting feature

### DIFF
--- a/.github/workflows/spelling_action.yml
+++ b/.github/workflows/spelling_action.yml
@@ -23,7 +23,7 @@ jobs:
         output_file: spellcheck-output.txt
 
     - uses: actions/upload-artifact@v3
-      name: Archive spellcheck output output
+      name: Archive spellcheck output
       with:
         name: Spellcheck artifact
         path: spellcheck-output.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,12 @@
       - uses: actions/checkout@v3
   
       - uses: rojopolis/spellcheck-github-actions@master
-        name: Spellcheck
+        name: Spellcheck (no output file)
+        with:
+          source_files: README.md CHANGELOG.md
+  
+      - uses: rojopolis/spellcheck-github-actions@master
+        name: Spellcheck (with output file)
         with:
           source_files: README.md CHANGELOG.md
           task_name: Markdown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Change Log for spellcheck-github-actions
 
+## 0.24.0, 2022-05-17, feature release, update not required
+
+- @riccardoporreca created issue [#68](https://github.com/rojopolis/spellcheck-github-actions/issues/68) requested the ability to create an output artifact.
+  
+  With release 0.24.0 this is now available.
+
+  The action configuration has to have the `output_file` parameter specified, which is a new optional parameter.
+
+  ```yaml
+  name: Spellcheck Action
+  
+  on:
+    workflow_dispatch:
+    push:
+  
+  jobs:
+    build:
+      name: Spellcheck
+      runs-on: ubuntu-latest
+      steps:
+  
+      - uses: actions/checkout@v3
+  
+      - uses: rojopolis/spellcheck-github-actions@master
+        name: Spellcheck
+        with:
+          source_files: README.md CHANGELOG.md
+          task_name: Markdown
+          output_file: spellcheck-output.txt
+  
+      - uses: actions/upload-artifact@v3
+        name: Archive spellcheck output output
+        with:
+          name: Spellcheck artifact
+          path: spellcheck-output.txt
+  ```
+
+  This introduces the use of the `upload-artifact@v3` action.
+
+  The generated artiface can be downloaded via GitHub UI/API, please consult the documentation for details and pointers.
+
+  Thanks to @riccardoporreca for his suggestion.
+
 ## 0.23.2, 2022-05-05, bug fix release, update not required
 
 - Minor issue in release 0.23.1, the action was not adjusted to the latest release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@
 
   This introduces the use of the `upload-artifact@v3` action.
 
-  The generated artiface can be downloaded via GitHub UI/API, please consult the documentation for details and pointers.
+  The generated artifact can be downloaded via GitHub UI/API, please consult the documentation for details and pointers.
 
   Thanks to @riccardoporreca for his suggestion.
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ jobs:
 
 In order to make it easier to process larger amount of output. The action allows for the user to enable the generation of an artifact.
 
-The `output_file` both enables the generation of the artifact and specifies the name of the file archived.
+The optional `output_file` input parameter, if specified, defines the name of the generated file containing the spellcheck output. Such file can then be stored as workflow artifact using the `actions/upload-artifact` step.
 
 A configuration for emitting an output artifact could look as follows.
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ jobs:
     steps:
     # The checkout step
     - uses: actions/checkout@master
-    - uses: rojopolis/spellcheck-github-actions@0.23.2
+    - uses: rojopolis/spellcheck-github-actions@0.24.0
       name: Spellcheck
 ```
 
@@ -106,11 +106,11 @@ source_files: "Managed Services/Security Monitor/README.md" "Terraform/Developme
 source_files: README.md CHANGELOG.md notes/Notes.md
 ```
 
-## Specify A Specific Task To Run
+## Specify a Specific Task To Run
 
 By default, all tasks in your config file will be run. By setting `task_name` you can override this and run only the task you require.
 
-A configuration for designated source files could look as follows:
+A configuration for designated source files could look as follows.
 
 Example:
 
@@ -125,12 +125,47 @@ jobs:
     steps:
     # The checkout step
     - uses: actions/checkout@master
-    - uses: rojopolis/spellcheck-github-actions@0.23.2
+    - uses: rojopolis/spellcheck-github-actions@0.24.0
       name: Spellcheck
       with:
         source_files: README.md CHANGELOG.md notes/Notes.md
         task_name: Markdown
 ```
+
+## Specify a PySpelling Output Artifact
+
+In order to make it easier to process larger amount of output. The action allows for the user to enable the generation of an artifact.
+
+The `output_file` both enables the generation of the artifact and specifies the name of the file archived.
+
+A configuration for emitting an output artifact could look as follows.
+
+Example:
+
+```yaml
+name: Spellcheck Action
+on: push
+
+jobs:
+  build:
+    name: Spellcheck
+    runs-on: ubuntu-latest
+    steps:
+    # The checkout step
+    - uses: actions/checkout@master
+    - uses: rojopolis/spellcheck-github-actions@0.24.0
+      name: Spellcheck
+      with:
+        source_files: README.md CHANGELOG.md notes/Notes.md
+        task_name: Markdown
+        output_file: spellcheck-output.txt
+```
+
+The artifact can be downloaded via the GitHub UI or via the GitHub API. The artifact is names: `Spellcheck artifact`, based on the name of the workflow (see above example).
+
+Do see the [official documentation](https://docs.github.com/en/rest/actions/artifacts#about-the-artifacts-api) for handling artifacts via the API.
+
+Artifacts are by default available for 3 months.
 
 ### Extra Configuration
 
@@ -198,7 +233,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: rojopolis/spellcheck-github-actions@0.23.2
+    - uses: rojopolis/spellcheck-github-actions@0.24.0
       name: Spellcheck
       with:
         config_path: config/.spellcheck.yml # put path to configuration file here
@@ -460,7 +495,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: rojopolis/spellcheck-github-actions@0.23.2
+    - uses: rojopolis/spellcheck-github-actions@0.24.0
       name: Spellcheck
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -16,8 +16,7 @@ inputs:
     required: false
   output_file:
     description: |
-      Indication that an artifact named `spellcheck-output.txt` 
-      containing output from pyspelling should be generated
+      Name of a generated output file containing output from pyspelling.
     required: false
 branding:
   color: green

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -88,8 +88,8 @@ fi
 
 echo "----------------------------------------------------------------"
 
-if [ -z "$OUTPUT_FILE" ]; then
-    pyspelling --config $SPELLCHECK_CONFIG_FILE $TASK_NAME $SOURCES_LIST | tee spellcheck-output.txt
+if [ -n "$INPUT_OUTPUT_FILE" ]; then
+    pyspelling --config $SPELLCHECK_CONFIG_FILE $TASK_NAME $SOURCES_LIST | tee $INPUT_OUTPUT_FILE
 else
     pyspelling --config $SPELLCHECK_CONFIG_FILE $TASK_NAME $SOURCES_LIST
 fi


### PR DESCRIPTION
The action can now emit an optional artifact, which is a text file containing the output from pyspelling. This can be enabled and specified via the new workflow parameter: output_file

This closes #68
