### PR TITLE
Add the pyspelling default configuration files

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,6 +11,12 @@ else
         SPELLCHECK_CONFIG_FILE=".spellcheck.yaml"
     elif [ -f "./spellcheck.yml" ]; then
         SPELLCHECK_CONFIG_FILE="spellcheck.yml"
+    elif [ -f "./spellcheck.yaml" ]; then
+        SPELLCHECK_CONFIG_FILE="spellcheck.yaml"
+    elif [ -f "./.pyspelling.yaml" ]; then
+        SPELLCHECK_CONFIG_FILE=".pyspelling.yaml"
+    elif [ -f "./.pyspelling.yml" ]; then
+        SPELLCHECK_CONFIG_FILE=".pyspelling.yml"
     else
         SPELLCHECK_CONFIG_FILE="spellcheck.yaml"
     fi


### PR DESCRIPTION
This change checks for the location of `.pyspelling.py` which is the default configuration file for PySpelling, and if it is there switches to use it.

Fixes #109 

