### PR TITLE
Update README.md - Fixed "Markdown" Appearing Twice

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ This action uses [PySpelling][pyspelling] to check spelling in source files in t
   - C++
   - HTML
   - JavaScript
-  - Markdown
   - ODF
   - OOXML
   - CSS


### PR DESCRIPTION
Hello, thank you for the great project! 

I just noticed that “Markdown” appears twice in the supported format list in the README.md file. 

This pull request deletes the second instance of "Markdown" from the list.