### PR TITLE
Addressing issue 213

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log for spellcheck-github-actions
 
+## 0.43.1, 2024-10-17, bug fix release, update recommended
+
+- This is an attempt at addressing the conflict between using the PySpelling `--source` parameter and the `sources` parameter in the PySpelling configuration file introduced by this action. With the recommendation of using the GitHub Action: [tj-actions/changed-files](https://github.com/marketplace/actions/changed-files), the use of the `--source` flag was adopted, but this bypasses the filtering mechanism, which can be enabled in the configuration file. The update recommendation is due to the fact that you might experience unwanted behaviour if your `sources` contain negated file patterns. The patch enables application of the configured filter to the source parameters, so the action can be used with the `--source` parameter and the `sources` configuration parameter in combination.
+
+  - Issue [#213](https://github.com/rojopolis/spellcheck-github-actions/issues/213)
+
 ## 0.43.0, 2024-10-08, maintenance release, update not required
 
 - Docker image updated to Python 3.12.7 slim via PR [#215](https://github.com/rojopolis/spellcheck-github-actions/pull/215) from Dependabot. [Release notes for Python 3.12.7](https://docs.python.org/release/3.12.7/whatsnew/changelog.html)

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,14 @@ LABEL "com.github.actions.description"="Check spelling of files in repository"
 LABEL "com.github.actions.icon"="clipboard"
 LABEL "com.github.actions.color"="green"
 LABEL "repository"="http://github.com/rojopolis/spellcheck-github-actions"
-LABEL "homepage"="http://github.com/actions"
+LABEL "homepage"="https://github.com/marketplace/actions/github-spellcheck-action"
 LABEL "maintainer"="rojopolis <rojo@deba.cl>"
 
 COPY entrypoint.sh /entrypoint.sh
 COPY requirements.txt /requirements.txt
 COPY constraint.txt /constraint.txt
 COPY spellcheck.yaml /spellcheck.yaml
+COPY pwc.py /pwc.py
 
 ENV PIP_CONSTRAINT=/constraint.txt
 RUN pip3 install -r /requirements.txt

--- a/pwc.py
+++ b/pwc.py
@@ -1,7 +1,7 @@
 #!python3
 
 # This little helper script was implemented to extract the sources from the spellcheck configuration file
-# The name comes from Python WCMatch, which is used to match the files against the sources
+# The name pwc comes from Python WCMatch, which is used to match the files against the sources
 # That is the short name I call it PriceWaterhouseCoopers, since it revises the file listing
 
 # read file and interpret it as yaml

--- a/pwc.py
+++ b/pwc.py
@@ -1,0 +1,41 @@
+#!python3
+
+# read file and interpret it as yaml
+def read_yaml(file):
+
+	with open(file) as f:
+		data = yaml.safe_load(f)
+	return data
+
+import sys
+import yaml
+#import pprint
+from wcmatch import glob
+
+# read filename from command line as first argument
+spellcheck_configuration_file = sys.argv[1]
+
+data = read_yaml(spellcheck_configuration_file)
+
+# fetch the sources from the YAML data
+sources = data.get('matrix')[0].get('sources')
+
+# print the sources from the YAML data
+#pprint.pprint(sources)
+
+for changed_file in sys.stdin:
+	if 'q' == changed_file.rstrip():
+		break
+	changed_file = changed_file.rstrip()
+	#print(f'Input : {changed_file}')
+
+	matched = glob.globmatch(changed_file, sources, flags=glob.NEGATE | glob.GLOBSTAR | glob.SPLIT)
+
+	if matched:
+		#print("Matched file:", changed_file)
+		exit(0)
+	else:
+		#print("No match for file:", changed_file)
+		exit(1)
+
+#pprint.pprint(files)

--- a/pwc.py
+++ b/pwc.py
@@ -1,5 +1,9 @@
 #!python3
 
+# This little helper script was implemented to extract the sources from the spellcheck configuration file
+# The name comes from Python WCMatch, which is used to match the files against the sources
+# That is the short name I call it PriceWaterhouseCoopers, since it revises the file listing
+
 # read file and interpret it as yaml
 def read_yaml(file):
 
@@ -9,7 +13,6 @@ def read_yaml(file):
 
 import sys
 import yaml
-#import pprint
 from wcmatch import glob
 
 # read filename from command line as first argument
@@ -20,22 +23,14 @@ data = read_yaml(spellcheck_configuration_file)
 # fetch the sources from the YAML data
 sources = data.get('matrix')[0].get('sources')
 
-# print the sources from the YAML data
-#pprint.pprint(sources)
-
 for changed_file in sys.stdin:
 	if 'q' == changed_file.rstrip():
 		break
 	changed_file = changed_file.rstrip()
-	#print(f'Input : {changed_file}')
 
 	matched = glob.globmatch(changed_file, sources, flags=glob.NEGATE | glob.GLOBSTAR | glob.SPLIT)
 
 	if matched:
-		#print("Matched file:", changed_file)
 		exit(0)
 	else:
-		#print("No match for file:", changed_file)
 		exit(1)
-
-#pprint.pprint(files)

--- a/test/test.bats
+++ b/test/test.bats
@@ -1,0 +1,41 @@
+@test "can do basic run using Docker image with two input files" {
+	docker run -e INPUT_SOURCE_FILES="README.md CHANGELOG.md" \
+           -e INPUT_TASK_NAME=Markdown -it -v $PWD:/tmp \
+           jonasbn/github-action-spellcheck:local
+}
+
+@test "can do basic run using Docker image with unignored and ignored input files" {
+	docker run -e INPUT_SOURCE_FILES="README.md venv/lib/python3.13/site-packages/pyspelling-2.10.dist-info/licenses/LICENSE.md" \
+           -e INPUT_TASK_NAME=Markdown -it -v $PWD:/tmp \
+           jonasbn/github-action-spellcheck:local
+}
+
+@test "can do basic run using Docker image with just ignored input file" {
+	docker run -e INPUT_SOURCE_FILES="venv/lib/python3.13/site-packages/pyspelling-2.10.dist-info/licenses/LICENSE.md" \
+           -e INPUT_TASK_NAME=Markdown -it -v $PWD:/tmp \
+           jonasbn/github-action-spellcheck:local
+}
+
+@test "can do basic run using Docker image without any input files" {
+	docker run \
+           -e INPUT_TASK_NAME=Markdown -it -v $PWD:/tmp \
+           jonasbn/github-action-spellcheck:local
+}
+
+@test "can do basic run using Docker image without task parameter" {
+	docker run \
+           -it -v $PWD:/tmp \
+           jonasbn/github-action-spellcheck:local
+}
+
+@test "can do basic run using Docker image with two input files but not task parameter" {
+	! docker run -e INPUT_SOURCE_FILES="README.md CHANGELOG.md" \
+           -it -v $PWD:/tmp \
+           jonasbn/github-action-spellcheck:local
+}
+
+@test "can do basic run using Docker image with two non-existing input files" {
+	! docker run -e INPUT_SOURCE_FILES="DONOTREADME.md LOGCHANGE.md" \
+           -e INPUT_TASK_NAME=Markdown -it -v $PWD:/tmp \
+           jonasbn/github-action-spellcheck:local
+}


### PR DESCRIPTION
This is an attempt at addressing the conflict between using the PySpelling `--source` parameter and the `sources` parameter in the PySpelling configuration file introduced by this action. With the recommendation of using the GitHub Action: [tj-actions/changed-files](https://github.com/marketplace/actions/changed-files), the use of the `--source` flag was adopted, but this bypasses the filtering mechanism, which can be enabled in the configuration file. The update recommendation is due to the fact that you might experience unwanted behaviour if your `sources` contain negated file patterns. The patch enables application of the configured filter to the source parameters, so the action can be used with the `--source` parameter and the `sources` configuration parameter in combination.

Fixes #213 
