### PR TITLE
Add tool versions to output

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,6 +24,8 @@ fi
 
 echo ""
 echo "Using pyspelling on configuration outlined in >$SPELLCHECK_CONFIG_FILE<"
+pyspelling --version
+aspell --version
 
 SINGLE="'"
 DOUBLE='"'


### PR DESCRIPTION
This pull request includes a small change to the `entrypoint.sh` script to add version number outputs to the log for `pyspelling` and `aspell` to provide more information during the script execution. This is helpful to me when comparing the locally installed versions of the tools to the versions that ran as part of a GitHub workflow.

[`entrypoint.sh`](diffhunk://#diff-6f9d41d046756f0ddc2fcee0626bdb50100d12b88f293734eff742818e03efa2R27-R28): Added commands to display the versions of `pyspelling` and `aspell` being used.

After this change, the log looks like this:

```text
Using pyspelling on configuration outlined in >.github/config/.pyspelling.yml<
pyspelling 2.10
@(#) International Ispell Version 3.1.20 (but really Aspell 0.60.8)
Checking files matching specification outlined in: >.github/config/.pyspelling.yml<
Using aspell to spellcheck Markdown
Running Task: Markdown...
```

Thank you! 🤖  