### PR TITLE
Docs/add relaxed header info

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ This action uses [PySpelling][pyspelling] to check spelling in source files in t
 
 ## Table of Contents
 
-- [Table of Contents](#table-of-contents)
 - [Features](#features)
 - [Configuration](#configuration)
   - [Using a Canonical Version](#using-a-canonical-version)


### PR DESCRIPTION
Add info on how to add relaxed_headers might be a good idea since many markdown tools (SSGs) use it.