### PR TITLE
Bump of core component pyspelling from 2.11 to 2.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ html5lib==1.1
 lxml==5.3.0
 Markdown==3.7
 pymdown-extensions==10.15.0
-pyspelling==2.11
+pyspelling==2.12
 PyYAML==6.0.2
 six==1.16.0
 soupsieve==2.6


### PR DESCRIPTION
The core component pyspelling has been updated from version `2.11` to `2.12`.

REF:
- https://github.com/facelessuser/pyspelling/releases/tag/2.12

> When jobs is set to 0, use maximum available cores.