### PR TITLE
Release 0.62.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log for spellcheck-github-actions
 
+## 0.62.0, 2026-06-19, security release, update recommended
+
+- Bumped `lxml` from 5.3.0 to 5.4.0 to address known CVEs via PR [#357](https://github.com/rojopolis/spellcheck-github-actions/pull/357).
+
+- Bumped `pymdown-extensions` to patched version 10.21.3 via PR [#358](https://github.com/rojopolis/spellcheck-github-actions/pull/358).
+
+- Bumped `Markdown` from 3.7 to 3.8.1 to patched version via PR [#359](https://github.com/rojopolis/spellcheck-github-actions/pull/359).
+
+- Cleaned up GitHub Actions workflows using `zizmor` and removed ratchet annotations via PR [#355](https://github.com/rojopolis/spellcheck-github-actions/pull/355) and PR [#356](https://github.com/rojopolis/spellcheck-github-actions/pull/356).
+
+- Clarified examples in README.
+
 ## 0.61.0, 2026-06-14, minor feature release, update not required
 
 - Docker based image updated for Python 3.14.5 slim trixie via PR [#344](https://github.com/rojopolis/spellcheck-github-actions/pull/344) from Dependabot.

--- a/README.md
+++ b/README.md
@@ -376,9 +376,9 @@ jobs:
       - name: Spellcheck
         uses: rojopolis/spellcheck-github-actions@0.62.0
         with:
-        config_path: config/.spellcheck.yml # put path to configuration file here
-        source_files: source/scanning.md source/triggers.md
-        task_name: Markdown
+          config_path: config/.spellcheck.yml # put path to configuration file here
+          source_files: source/scanning.md source/triggers.md
+          task_name: Markdown
 ```
 
 ### Predefined Name
@@ -622,8 +622,8 @@ jobs:
       - name: Spellcheck
         uses: rojopolis/spellcheck-github-actions@0.62.0
         with:
-        config_path: .github/spellcheck.yml
-        skip_dict_compile: true # <--- set to true to skip custom dictionary compilation
+          config_path: .github/spellcheck.yml
+          skip_dict_compile: true # <--- set to true to skip custom dictionary compilation
 ```
 
 This can be useful if you have a large custom dictionary that does not change often, as it can save time during the action run.
@@ -662,7 +662,7 @@ jobs:
       - name: Spellcheck
         uses: rojopolis/spellcheck-github-actions@0.62.0
         with:
-        config_path: .github/spellcheck.yml # <--- put path to configuration file here
+          config_path: .github/spellcheck.yml # <--- put path to configuration file here
 ```
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ jobs:
           persist-credentials: false
 
       - name: Spellcheck
-        uses: rojopolis/spellcheck-github-actions@0.61.0
+        uses: rojopolis/spellcheck-github-actions@0.62.0
 ```
 
 This configuration file must be created in a the `.github/workflows/` directory.
@@ -230,7 +230,7 @@ jobs:
           persist-credentials: false
 
       - name: Spellcheck
-        uses: rojopolis/spellcheck-github-actions@0.61.0
+        uses: rojopolis/spellcheck-github-actions@0.62.0
         with:
           source_files: README.md CHANGELOG.md notes/Notes.md
           task_name: Markdown
@@ -265,7 +265,7 @@ jobs:
         persist-credentials: false
 
     - name: Spellcheck
-      uses: rojopolis/spellcheck-github-actions@0.61.0
+      uses: rojopolis/spellcheck-github-actions@0.62.0
       with:
         source_files: README.md CHANGELOG.md notes/Notes.md
         task_name: Markdown
@@ -374,7 +374,7 @@ jobs:
           persist-credentials: false
 
       - name: Spellcheck
-        uses: rojopolis/spellcheck-github-actions@0.61.0
+        uses: rojopolis/spellcheck-github-actions@0.62.0
         with:
         config_path: config/.spellcheck.yml # put path to configuration file here
         source_files: source/scanning.md source/triggers.md
@@ -505,7 +505,7 @@ The action can be specified to use `hunspell` instead of `aspell` by setting the
 
 ```yaml
     - name: Spellcheck
-      uses: rojopolis/spellcheck-github-actions@0.61.0
+      uses: rojopolis/spellcheck-github-actions@0.62.0
       with:
         task_name: Markdown
         spell_checker: hunspell
@@ -620,7 +620,7 @@ jobs:
           persist-credentials: false
 
       - name: Spellcheck
-        uses: rojopolis/spellcheck-github-actions@0.61.0
+        uses: rojopolis/spellcheck-github-actions@0.62.0
         with:
         config_path: .github/spellcheck.yml
         skip_dict_compile: true # <--- set to true to skip custom dictionary compilation
@@ -660,7 +660,7 @@ jobs:
           persist-credentials: false
 
       - name: Spellcheck
-        uses: rojopolis/spellcheck-github-actions@0.61.0
+        uses: rojopolis/spellcheck-github-actions@0.62.0
         with:
         config_path: .github/spellcheck.yml # <--- put path to configuration file here
 ```
@@ -909,7 +909,7 @@ jobs:
           persist-credentials: false
 
       - name: Spellcheck
-        uses: rojopolis/spellcheck-github-actions@0.61.0
+        uses: rojopolis/spellcheck-github-actions@0.62.0
 ```
 
 This step adds an action, which checkout out the repository for inspection by linters and other actions like this one.

--- a/action.yml
+++ b/action.yml
@@ -33,4 +33,4 @@ branding:
   icon: type
 runs:
   using: docker
-  image: 'docker://jonasbn/github-action-spellcheck:0.61.0'
+  image: 'docker://jonasbn/github-action-spellcheck:0.62.0'

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -3,6 +3,7 @@ Arithmatex
 BetterEm
 Brømsø
 CVE
+CVEs
 CWE
 Cavalcanti
 Customizable


### PR DESCRIPTION
## Release 0.62.0 — security release, update recommended

### Changes since 0.61.0

- Bumped `lxml` from 5.3.0 to 5.4.0 to address known CVEs (#357)
- Bumped `pymdown-extensions` to patched version 10.21.3 (#358)
- Bumped `Markdown` from 3.7 to 3.8.1 to patched version (#359)
- Cleaned up GitHub Actions workflows using `zizmor` and removed ratchet annotations (#355, #356)
- Clarified examples in README

### Files changed

- `action.yml` — image bumped to `0.62.0`
- `README.md` — all `uses:` references bumped to `0.62.0`
- `CHANGELOG.md` — entry added for `0.62.0`