### PR TITLE
Release 0.63.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log for spellcheck-github-actions
 
+## 0.63.0, 2026-07-01, maintenance release, update not required
+
+- Docker based image updated for Python 3.14.6 slim trixie via PR [#364](https://github.com/rojopolis/spellcheck-github-actions/pull/364) from Dependabot.
+
 ## 0.62.0, 2026-06-19, security release, update recommended
 
 - Bumped `lxml` from 5.3.0 to 5.4.0 to address known CVEs via PR [#357](https://github.com/rojopolis/spellcheck-github-actions/pull/357).

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ jobs:
           persist-credentials: false
 
       - name: Spellcheck
-        uses: rojopolis/spellcheck-github-actions@0.62.0
+        uses: rojopolis/spellcheck-github-actions@0.63.0
 ```
 
 This configuration file must be created in a the `.github/workflows/` directory.
@@ -230,7 +230,7 @@ jobs:
           persist-credentials: false
 
       - name: Spellcheck
-        uses: rojopolis/spellcheck-github-actions@0.62.0
+        uses: rojopolis/spellcheck-github-actions@0.63.0
         with:
           source_files: README.md CHANGELOG.md notes/Notes.md
           task_name: Markdown
@@ -265,7 +265,7 @@ jobs:
         persist-credentials: false
 
     - name: Spellcheck
-      uses: rojopolis/spellcheck-github-actions@0.62.0
+      uses: rojopolis/spellcheck-github-actions@0.63.0
       with:
         source_files: README.md CHANGELOG.md notes/Notes.md
         task_name: Markdown
@@ -374,7 +374,7 @@ jobs:
           persist-credentials: false
 
       - name: Spellcheck
-        uses: rojopolis/spellcheck-github-actions@0.62.0
+        uses: rojopolis/spellcheck-github-actions@0.63.0
         with:
           config_path: config/.spellcheck.yml # put path to configuration file here
           source_files: source/scanning.md source/triggers.md
@@ -505,7 +505,7 @@ The action can be specified to use `hunspell` instead of `aspell` by setting the
 
 ```yaml
     - name: Spellcheck
-      uses: rojopolis/spellcheck-github-actions@0.62.0
+      uses: rojopolis/spellcheck-github-actions@0.63.0
       with:
         task_name: Markdown
         spell_checker: hunspell
@@ -620,7 +620,7 @@ jobs:
           persist-credentials: false
 
       - name: Spellcheck
-        uses: rojopolis/spellcheck-github-actions@0.62.0
+        uses: rojopolis/spellcheck-github-actions@0.63.0
         with:
           config_path: .github/spellcheck.yml
           skip_dict_compile: true # <--- set to true to skip custom dictionary compilation
@@ -660,7 +660,7 @@ jobs:
           persist-credentials: false
 
       - name: Spellcheck
-        uses: rojopolis/spellcheck-github-actions@0.62.0
+        uses: rojopolis/spellcheck-github-actions@0.63.0
         with:
           config_path: .github/spellcheck.yml # <--- put path to configuration file here
 ```
@@ -909,7 +909,7 @@ jobs:
           persist-credentials: false
 
       - name: Spellcheck
-        uses: rojopolis/spellcheck-github-actions@0.62.0
+        uses: rojopolis/spellcheck-github-actions@0.63.0
 ```
 
 This step adds an action, which checkout out the repository for inspection by linters and other actions like this one.

--- a/action.yml
+++ b/action.yml
@@ -33,4 +33,4 @@ branding:
   icon: type
 runs:
   using: docker
-  image: 'docker://jonasbn/github-action-spellcheck:0.62.0'
+  image: 'docker://jonasbn/github-action-spellcheck:0.63.0'


### PR DESCRIPTION
## Summary

- Bumps `action.yml` image to `docker://jonasbn/github-action-spellcheck:0.63.0`
- Updates all `uses: rojopolis/spellcheck-github-actions@0.62.0` references in `README.md` to `0.63.0`
- Adds `CHANGELOG.md` entry for `0.63.0` (maintenance release — Python 3.14.6 base image)

## Changes since 0.62.0

- Bump `actions/checkout` from 6.0.3 to 7.0.0 (#365)
- Bump `rojopolis/spellcheck-github-actions` from 0.61.0 to 0.62.0 in workflows (#366)
- Update CLAUDE.md with release workflow and Dependabot gotchas (#363)
- Bump Python base image from 3.14.5-slim-trixie to 3.14.6-slim-trixie (#364) — tested locally, spellcheck passed

## Test plan

- [x] Docker image built locally from PR #364 branch
- [x] Spellcheck smoke test passed against this repo
- [ ] Merge this PR
- [ ] Run `perl scripts/build.pl 0.63.0` to tag and push to GitHub and DockerHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)