### PR TITLE
Bump bracex from 2.5.post1 to 3.0.1 to fix glob source matching

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 backrefs==5.6
 beautifulsoup4==4.12.3
-bracex==2.5.post1
+bracex==3.0.1
 html5lib==1.1
 lxml==5.4.0
 Markdown==3.8.1


### PR DESCRIPTION
## Summary

- Fixes #378 — sources patterns combining brace expansion, `SPLIT`, and `GLOBSTAR` (e.g. `**/*.{c,h}|!build/**`) matched zero files inside the Docker image, even though the same pattern worked with a locally `pip install`ed `pyspelling`.
- Root cause: `requirements.txt` pinned `bracex==2.5.post1`, which predates the version `wcmatch` 10.2+ itself requires for correct brace-expansion parsing (see `wcmatch`'s own changelog: "Require `bracex` 3.0 for bug fixes"). The image had drifted onto this stale, incompatible pair because the pip layer isn't re-resolved unless `requirements.txt`/`Dockerfile` change.
- Bumps `bracex` to the current `3.0.1`, which is compatible with the `wcmatch` versions already in use.

## Verification

- Reproduced the exact `RuntimeError: None of the source targets from the configuration match any files` reported in #378 by pulling the published `jonasbn/github-action-spellcheck:0.63.0` image and running it against the reporter's real config (`arkq/bluez-alsa`, `.github/spellcheck.yaml`, pattern `**/*.{c,h}|!build/**`).
- Confirmed that upgrading **only** `bracex` (leaving `wcmatch` untouched) inside that same image resolves the error and the run completes with "Spelling check passed".
- Built this branch's image locally (`docker build -t jonasbn/github-action-spellcheck:local .`) and reran it against the same `bluez-alsa` checkout — passes.
- Ran the non-interactive smoke test (`docker run -v $PWD:/tmp jonasbn/github-action-spellcheck:local`) against this repo — passes.
- `pre-commit run --files requirements.txt` — passes.

## Test plan

- [x] Reproduce #378 against the published `0.63.0` image
- [x] Confirm the bracex bump alone fixes it in that image
- [x] Rebuild locally with the pin bumped and rerun against the reporter's config
- [x] Smoke test against this repo's own `spellcheck.yaml`
- [x] `pre-commit` hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)