### PR TITLE
Release 0.63.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log for spellcheck-github-actions
 
+## 0.63.1, 2026-07-30, bug fix release, update recommended
+
+- Fixed `sources` glob patterns that combine brace expansion with the `SPLIT`/`GLOBSTAR` flags (e.g. `**/*.{c,h}|!build/**`) silently matching zero files and causing the action to fail with `RuntimeError: None of the source targets from the configuration match any files`. The pinned `bracex` dependency (`2.5.post1`) predated the version `wcmatch` requires for correct parsing of such patterns; bumped to `3.0.1` via PR [#379](https://github.com/rojopolis/spellcheck-github-actions/pull/379). Addresses issue [#378](https://github.com/rojopolis/spellcheck-github-actions/issues/378), reported by @arkq.
+
 ## 0.63.0, 2026-07-01, maintenance release, update not required
 
 - Docker based image updated for Python 3.14.6 slim trixie via PR [#364](https://github.com/rojopolis/spellcheck-github-actions/pull/364) from Dependabot.

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ jobs:
           persist-credentials: false
 
       - name: Spellcheck
-        uses: rojopolis/spellcheck-github-actions@0.63.0
+        uses: rojopolis/spellcheck-github-actions@0.63.1
 ```
 
 This configuration file must be created in a the `.github/workflows/` directory.
@@ -230,7 +230,7 @@ jobs:
           persist-credentials: false
 
       - name: Spellcheck
-        uses: rojopolis/spellcheck-github-actions@0.63.0
+        uses: rojopolis/spellcheck-github-actions@0.63.1
         with:
           source_files: README.md CHANGELOG.md notes/Notes.md
           task_name: Markdown
@@ -265,7 +265,7 @@ jobs:
         persist-credentials: false
 
     - name: Spellcheck
-      uses: rojopolis/spellcheck-github-actions@0.63.0
+      uses: rojopolis/spellcheck-github-actions@0.63.1
       with:
         source_files: README.md CHANGELOG.md notes/Notes.md
         task_name: Markdown
@@ -374,7 +374,7 @@ jobs:
           persist-credentials: false
 
       - name: Spellcheck
-        uses: rojopolis/spellcheck-github-actions@0.63.0
+        uses: rojopolis/spellcheck-github-actions@0.63.1
         with:
           config_path: config/.spellcheck.yml # put path to configuration file here
           source_files: source/scanning.md source/triggers.md
@@ -505,7 +505,7 @@ The action can be specified to use `hunspell` instead of `aspell` by setting the
 
 ```yaml
     - name: Spellcheck
-      uses: rojopolis/spellcheck-github-actions@0.63.0
+      uses: rojopolis/spellcheck-github-actions@0.63.1
       with:
         task_name: Markdown
         spell_checker: hunspell
@@ -620,7 +620,7 @@ jobs:
           persist-credentials: false
 
       - name: Spellcheck
-        uses: rojopolis/spellcheck-github-actions@0.63.0
+        uses: rojopolis/spellcheck-github-actions@0.63.1
         with:
           config_path: .github/spellcheck.yml
           skip_dict_compile: true # <--- set to true to skip custom dictionary compilation
@@ -660,7 +660,7 @@ jobs:
           persist-credentials: false
 
       - name: Spellcheck
-        uses: rojopolis/spellcheck-github-actions@0.63.0
+        uses: rojopolis/spellcheck-github-actions@0.63.1
         with:
           config_path: .github/spellcheck.yml # <--- put path to configuration file here
 ```
@@ -909,7 +909,7 @@ jobs:
           persist-credentials: false
 
       - name: Spellcheck
-        uses: rojopolis/spellcheck-github-actions@0.63.0
+        uses: rojopolis/spellcheck-github-actions@0.63.1
 ```
 
 This step adds an action, which checkout out the repository for inspection by linters and other actions like this one.

--- a/action.yml
+++ b/action.yml
@@ -33,4 +33,4 @@ branding:
   icon: type
 runs:
   using: docker
-  image: 'docker://jonasbn/github-action-spellcheck:0.63.0'
+  image: 'docker://jonasbn/github-action-spellcheck:0.63.1'

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -64,6 +64,7 @@ aSemy
 aicore
 akohout
 albertvolkman
+arkq
 backrefs
 beautifulsoup
 bracex


### PR DESCRIPTION
## Summary

- Release prep for `0.63.1`, a bug fix release shipping PR #379 (fixes #378).
- Updates `action.yml`'s pinned image tag from `0.63.0` to `0.63.1`.
- Updates all pinned `uses: rojopolis/spellcheck-github-actions@0.63.0` references in `README.md` to `@0.63.1` (the two `@v0` floating references are intentionally left untouched).
- `CHANGELOG.md` already has the `0.63.1` entry describing the fix.

## Test plan

- [x] `pre-commit run` on the changed files
- [ ] Merge, then run `perl scripts/build.pl 0.63.1` to tag and push to GitHub/DockerHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)