### PR TITLE
Release 0.64.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,24 +259,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Checkout repository
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      with:
-        persist-credentials: false
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
-    - name: Spellcheck
-      uses: rojopolis/spellcheck-github-actions@0.64.0
-      with:
-        source_files: README.md CHANGELOG.md notes/Notes.md
-        task_name: Markdown
-        output_file: spellcheck-output.txt
+      - name: Spellcheck
+        uses: rojopolis/spellcheck-github-actions@0.64.0
+        with:
+          source_files: README.md CHANGELOG.md notes/Notes.md
+          task_name: Markdown
+          output_file: spellcheck-output.txt
 
-    - name: Archive spellcheck output
-      uses: actions/upload-artifact@v3
-      if: '!cancelled()' # Do not upload artifact if job was cancelled
-      with:
-        name: Spellcheck Output
-        path: spellcheck-output.txt
+      - name: Archive spellcheck output
+        uses: actions/upload-artifact@v3
+        if: '!cancelled()' # Do not upload artifact if job was cancelled
+        with:
+          name: Spellcheck Output
+          path: spellcheck-output.txt
 ```
 
 The artifact can be downloaded via the GitHub UI or via the GitHub API. The artifact is named: `Spellcheck Outout`, based on the name specified in the above example and the file is named: `spellcheck-output.txt`, based on the name specified in the above example, it comes zipped.

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ jobs:
           persist-credentials: false
 
       - name: Spellcheck
-        uses: rojopolis/spellcheck-github-actions@0.63.1
+        uses: rojopolis/spellcheck-github-actions@0.64.0
 ```
 
 This configuration file must be created in a the `.github/workflows/` directory.
@@ -230,7 +230,7 @@ jobs:
           persist-credentials: false
 
       - name: Spellcheck
-        uses: rojopolis/spellcheck-github-actions@0.63.1
+        uses: rojopolis/spellcheck-github-actions@0.64.0
         with:
           source_files: README.md CHANGELOG.md notes/Notes.md
           task_name: Markdown
@@ -265,7 +265,7 @@ jobs:
         persist-credentials: false
 
     - name: Spellcheck
-      uses: rojopolis/spellcheck-github-actions@0.63.1
+      uses: rojopolis/spellcheck-github-actions@0.64.0
       with:
         source_files: README.md CHANGELOG.md notes/Notes.md
         task_name: Markdown
@@ -374,7 +374,7 @@ jobs:
           persist-credentials: false
 
       - name: Spellcheck
-        uses: rojopolis/spellcheck-github-actions@0.63.1
+        uses: rojopolis/spellcheck-github-actions@0.64.0
         with:
           config_path: config/.spellcheck.yml # put path to configuration file here
           source_files: source/scanning.md source/triggers.md
@@ -505,7 +505,7 @@ The action can be specified to use `hunspell` instead of `aspell` by setting the
 
 ```yaml
     - name: Spellcheck
-      uses: rojopolis/spellcheck-github-actions@0.63.1
+      uses: rojopolis/spellcheck-github-actions@0.64.0
       with:
         task_name: Markdown
         spell_checker: hunspell
@@ -620,7 +620,7 @@ jobs:
           persist-credentials: false
 
       - name: Spellcheck
-        uses: rojopolis/spellcheck-github-actions@0.63.1
+        uses: rojopolis/spellcheck-github-actions@0.64.0
         with:
           config_path: .github/spellcheck.yml
           skip_dict_compile: true # <--- set to true to skip custom dictionary compilation
@@ -660,7 +660,7 @@ jobs:
           persist-credentials: false
 
       - name: Spellcheck
-        uses: rojopolis/spellcheck-github-actions@0.63.1
+        uses: rojopolis/spellcheck-github-actions@0.64.0
         with:
           config_path: .github/spellcheck.yml # <--- put path to configuration file here
 ```
@@ -909,7 +909,7 @@ jobs:
           persist-credentials: false
 
       - name: Spellcheck
-        uses: rojopolis/spellcheck-github-actions@0.63.1
+        uses: rojopolis/spellcheck-github-actions@0.64.0
 ```
 
 This step adds an action, which checkout out the repository for inspection by linters and other actions like this one.

--- a/action.yml
+++ b/action.yml
@@ -33,4 +33,4 @@ branding:
   icon: type
 runs:
   using: docker
-  image: 'docker://jonasbn/github-action-spellcheck:0.63.1'
+  image: 'docker://jonasbn/github-action-spellcheck:0.64.0'


### PR DESCRIPTION
## Summary

- Release prep for `0.64.0`, a maintenance release shipping PR #380 (pip-compile dependency management migration).
- Updates `action.yml`'s pinned image tag from `0.63.1` to `0.64.0`.
- Updates all pinned `uses: rojopolis/spellcheck-github-actions@0.63.1` references in `README.md` to `@0.64.0` (the two `@v0` floating references are intentionally left untouched).
- `CHANGELOG.md` already has the `0.64.0` entry (added alongside PR #380).

## Test plan

- [x] `pre-commit run` on the changed files
- [ ] Merge, then run `perl scripts/build.pl 0.64.0` to tag and push to GitHub/DockerHub
- [ ] Update the wiki's Sunset Schedule Gantt chart once released (see `CLAUDE.md` → Releasing → Wiki)

🤖 Generated with [Claude Code](https://claude.com/claude-code)