### PR TITLE
Document CLAUDE.md learnings from 0.64.0 release cycle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,3 +143,8 @@ The Docker image is published via the `docker-build.yml` workflow on push to `ma
 ## README YAML Examples
 
 - Inputs under `with:` in workflow YAML examples must be indented 2 spaces relative to `with:`. This has been a recurring source of invalid examples.
+- Don't trust a reviewer's (e.g. Copilot's) "this is invalid YAML" claim at face value — verify with `python3 -c "import yaml; yaml.safe_load(open('README.md').read())"` on the extracted block. Same-indentation block sequences (list items aligned with their parent key) are valid YAML even though they look wrong; the real issue is usually inconsistency with this file's convention, not invalidity.
+
+## Working on Open Branches
+
+- Branches behind open PRs may receive direct pushes from the user (e.g. resolving a merge conflict via the GitHub UI) while a session is in progress. A local `git push` can be rejected as a result — `git fetch` and merge (don't force-push) before retrying.


### PR DESCRIPTION
## Summary

- Adds two `CLAUDE.md` notes from working through the #378/#379/#380/0.63.1/0.64.0 cycle:
  - Verify a reviewer's "invalid YAML" claim with an actual parser before acting on it — same-indentation block sequences are valid YAML, just inconsistent with this file's own convention.
  - Open PR branches in this repo can receive direct pushes from the user (e.g. resolving a conflict via the GitHub UI) mid-session — fetch and merge rather than assuming a clean fast-forward push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)