### PR TITLE
Release 0.65.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log for spellcheck-github-actions
 
+## `0.65.0`, 2026-08-08, security release, update recommended
+
+- Bumped `lxml` from `5.4.0` to `6.1.1` to address [CVE-2026-41066](https://nvd.nist.gov/vuln/detail/CVE-2026-41066) (XXE via `iterparse()`/`ETCompatXMLParser` defaulting `resolve_entities=True`) and libxslt vulnerabilities [CVE-2025-7424](https://nvd.nist.gov/vuln/detail/CVE-2025-7424) and [CVE-2025-11731](https://nvd.nist.gov/vuln/detail/CVE-2025-11731), via PR [#388](https://github.com/rojopolis/spellcheck-github-actions/pull/388) from Dependabot.
+
 ## 0.64.0, 2026-07-31, maintenance release, update not required
 
 - Adopted `pip-compile` (pip-tools) for Python dependency management via PR [#380](https://github.com/rojopolis/spellcheck-github-actions/pull/380). `requirements.in` is now the source of truth for direct dependencies (`pyspelling`, `pymdown-extensions`); `requirements.txt` is generated from it rather than hand-maintained, so transitive pins can no longer silently fall out of sync the way `bracex` did in issue [#378](https://github.com/rojopolis/spellcheck-github-actions/issues/378).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Bumped `lxml` from `5.4.0` to `6.1.1` to address [CVE-2026-41066](https://nvd.nist.gov/vuln/detail/CVE-2026-41066) (XXE via `iterparse()`/`ETCompatXMLParser` defaulting `resolve_entities=True`) and libxslt vulnerabilities [CVE-2025-7424](https://nvd.nist.gov/vuln/detail/CVE-2025-7424) and [CVE-2025-11731](https://nvd.nist.gov/vuln/detail/CVE-2025-11731), via PR [#388](https://github.com/rojopolis/spellcheck-github-actions/pull/388) from Dependabot.
 
+- Bumped `pymdown-extensions` from `10.21.3` to `11.0.1` to address [CVE-2026-67422](https://nvd.nist.gov/vuln/detail/CVE-2026-67422) (ReDoS in the caret, tilde, betterem, and magiclink inline processors) and [CVE-2026-61632](https://nvd.nist.gov/vuln/detail/CVE-2026-61632) (path traversal in the `b64` extension).
+
+- Bumped `soupsieve` from `2.6` to `2.9.2` to address [CVE-2026-49476](https://nvd.nist.gov/vuln/detail/CVE-2026-49476) (memory exhaustion via large comma-separated selector lists) and [CVE-2026-49477](https://nvd.nist.gov/vuln/detail/CVE-2026-49477) (ReDoS via the selector parser).
+
 ## 0.64.0, 2026-07-31, maintenance release, update not required
 
 - Adopted `pip-compile` (pip-tools) for Python dependency management via PR [#380](https://github.com/rojopolis/spellcheck-github-actions/pull/380). `requirements.in` is now the source of truth for direct dependencies (`pyspelling`, `pymdown-extensions`); `requirements.txt` is generated from it rather than hand-maintained, so transitive pins can no longer silently fall out of sync the way `bracex` did in issue [#378](https://github.com/rojopolis/spellcheck-github-actions/issues/378).

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ jobs:
           persist-credentials: false
 
       - name: Spellcheck
-        uses: rojopolis/spellcheck-github-actions@0.64.0
+        uses: rojopolis/spellcheck-github-actions@0.65.0
 ```
 
 This configuration file must be created in a the `.github/workflows/` directory.
@@ -230,7 +230,7 @@ jobs:
           persist-credentials: false
 
       - name: Spellcheck
-        uses: rojopolis/spellcheck-github-actions@0.64.0
+        uses: rojopolis/spellcheck-github-actions@0.65.0
         with:
           source_files: README.md CHANGELOG.md notes/Notes.md
           task_name: Markdown
@@ -265,7 +265,7 @@ jobs:
           persist-credentials: false
 
       - name: Spellcheck
-        uses: rojopolis/spellcheck-github-actions@0.64.0
+        uses: rojopolis/spellcheck-github-actions@0.65.0
         with:
           source_files: README.md CHANGELOG.md notes/Notes.md
           task_name: Markdown
@@ -374,7 +374,7 @@ jobs:
           persist-credentials: false
 
       - name: Spellcheck
-        uses: rojopolis/spellcheck-github-actions@0.64.0
+        uses: rojopolis/spellcheck-github-actions@0.65.0
         with:
           config_path: config/.spellcheck.yml # put path to configuration file here
           source_files: source/scanning.md source/triggers.md
@@ -505,7 +505,7 @@ The action can be specified to use `hunspell` instead of `aspell` by setting the
 
 ```yaml
     - name: Spellcheck
-      uses: rojopolis/spellcheck-github-actions@0.64.0
+      uses: rojopolis/spellcheck-github-actions@0.65.0
       with:
         task_name: Markdown
         spell_checker: hunspell
@@ -620,7 +620,7 @@ jobs:
           persist-credentials: false
 
       - name: Spellcheck
-        uses: rojopolis/spellcheck-github-actions@0.64.0
+        uses: rojopolis/spellcheck-github-actions@0.65.0
         with:
           config_path: .github/spellcheck.yml
           skip_dict_compile: true # <--- set to true to skip custom dictionary compilation
@@ -660,7 +660,7 @@ jobs:
           persist-credentials: false
 
       - name: Spellcheck
-        uses: rojopolis/spellcheck-github-actions@0.64.0
+        uses: rojopolis/spellcheck-github-actions@0.65.0
         with:
           config_path: .github/spellcheck.yml # <--- put path to configuration file here
 ```
@@ -909,7 +909,7 @@ jobs:
           persist-credentials: false
 
       - name: Spellcheck
-        uses: rojopolis/spellcheck-github-actions@0.64.0
+        uses: rojopolis/spellcheck-github-actions@0.65.0
 ```
 
 This step adds an action, which checkout out the repository for inspection by linters and other actions like this one.

--- a/action.yml
+++ b/action.yml
@@ -33,4 +33,4 @@ branding:
   icon: type
 runs:
   using: docker
-  image: 'docker://jonasbn/github-action-spellcheck:0.64.0'
+  image: 'docker://jonasbn/github-action-spellcheck:0.65.0'

--- a/requirements.in
+++ b/requirements.in
@@ -1,2 +1,2 @@
 pyspelling==2.12.1
-pymdown-extensions==10.21.3
+pymdown-extensions==11.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ markdown==3.8.1
     # via
     #   pymdown-extensions
     #   pyspelling
-pymdown-extensions==10.21.3
+pymdown-extensions==11.0.1
     # via -r requirements.in
 pyspelling==2.12.1
     # via -r requirements.in
@@ -26,7 +26,7 @@ pyyaml==6.0.2
     #   pyspelling
 six==1.16.0
     # via html5lib
-soupsieve==2.6
+soupsieve==2.9.2
     # via
     #   beautifulsoup4
     #   pyspelling

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -40,6 +40,7 @@ PyPi
 PySpelling
 PyYAML
 README
+ReDoS
 Riccardo
 SNYK
 SVG
@@ -68,6 +69,7 @@ albertvolkman
 arkq
 backrefs
 beautifulsoup
+betterem
 bracex
 brooke
 chrispat
@@ -99,6 +101,7 @@ libxml
 libxslt
 linters
 lxml
+magiclink
 mdiazgoncalves
 metaode
 metaodi

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -59,6 +59,7 @@ Vitepress
 Volkman
 Wordlist
 XSS
+XXE
 YAML
 aSemy
 aicore


### PR DESCRIPTION
## Summary
- Bumps the pinned image/version references for this action's release from `0.64.0` to `0.65.0`.
- Addresses 3 open Dependabot security alerts on `master` (3 high, 1 moderate) by bumping:
  - `lxml` `5.4.0` → `6.1.1` (PR #388) — CVE-2026-41066, CVE-2025-7424, CVE-2025-11731
  - `pymdown-extensions` `10.21.3` → `11.0.1` (direct dependency, bumped in `requirements.in`) — CVE-2026-67422, CVE-2026-61632
  - `soupsieve` `2.6` → `2.9.2` (transitive, via `pip-compile --upgrade-package`) — CVE-2026-49476, CVE-2026-49477
- Updates `action.yml` image tag and all pinned `uses: rojopolis/spellcheck-github-actions@X.Y.Z` references in `README.md` (leaving the floating `@v0` references untouched).
- Adds `XXE` to `wordlist.txt` (needed by the new CHANGELOG entry's CVE description).
- Adds the `0.65.0` CHANGELOG entry.

## Related
- #388
- Dependabot alerts #8, #9, #10, #11 (soupsieve x2, pymdown-extensions x2)

## Test plan
- [x] Confirmed `lxml==6.1.1`, `pymdown-extensions==11.0.1`, `soupsieve==2.9.2` have no upper-bound conflicts with `pyspelling`'s / `beautifulsoup4`'s declared metadata
- [x] Regenerated `requirements.txt` via `pip-compile` under Python 3.14 (matching the Dockerfile base)
- [x] Rebuilt `jonasbn/github-action-spellcheck:local` and ran the smoke test against this repo — spelling check passes
- [ ] After merge: run `perl scripts/build.pl 0.65.0` to tag and push to GitHub and Docker Hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)